### PR TITLE
Enable compilation on Windows

### DIFF
--- a/stubborn_buddies/CMakeLists.txt
+++ b/stubborn_buddies/CMakeLists.txt
@@ -14,6 +14,7 @@ endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 # find dependencies
 find_package(ament_cmake REQUIRED)


### PR DESCRIPTION
## Bug fix

### Fixed bug

The package compiles a shared library, but does not expose any symbol on Windows, so the generated shared library can't be used.

### Fix applied

On Linux and macOS, everything compiles fine as by default all the symbols are visible. We can achieve exactly the same behavior in Windows by setting to `ON` the [`CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS`](https://cmake.org/cmake/help/v3.4/variable/CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS.html) CMake variable.